### PR TITLE
Add rspec and some specs

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--color
+--format documentation
+--require spec_helper

--- a/rhymer.gemspec
+++ b/rhymer.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "natto", "~> 1.1.0"
   spec.add_runtime_dependency "thor", "~> 0.19.1"
+  spec.add_development_dependency "rspec", "~> 3.4.0"
 end

--- a/spec/rhymer/cli_spec.rb
+++ b/spec/rhymer/cli_spec.rb
@@ -1,0 +1,12 @@
+describe Rhymer::CLI do
+  let(:cli) { described_class.new }
+
+  describe '#spit' do
+    context 'given text' do
+      let(:text) { '今日はとても良い天気ですね。こんな日は自然に元気になります。' }
+
+      subject { -> { cli.spit(text) } }
+      it { is_expected.to output("今日は良い天気 こんな日は自然に元気\n").to_stdout }
+    end
+  end
+end

--- a/spec/rhymer/lyric_spec.rb
+++ b/spec/rhymer/lyric_spec.rb
@@ -1,0 +1,49 @@
+describe Rhymer::Lyric do
+  let(:text) { '今日はとても良い天気ですね。' }
+  let(:lyric) { described_class.new(text) }
+
+  describe '.new' do
+    context 'given text' do
+      subject { lyric }
+      it { is_expected.to be_instance_of described_class }
+      it { is_expected.to respond_to(:lyric) }
+      it { is_expected.not_to respond_to(:lyric=) }
+    end
+
+    context 'given nil text' do
+      let(:text) { nil }
+
+      subject { -> { lyric } }
+      it { is_expected.to raise_error(ArgumentError, 'Text to parse cannot be nil') }
+    end
+  end
+
+  describe '#lyric' do
+    subject { lyric.lyric }
+    it { is_expected.to include an_instance_of(Natto::MeCabNode) }
+  end
+
+  describe '#mecab' do
+    subject { lyric.mecab }
+    it { is_expected.to be_instance_of Natto::MeCab }
+  end
+
+  describe '#nauns' do
+    let(:nauns) do
+      {
+        0 => an_instance_of(Natto::MeCabNode),
+        4 => an_instance_of(Natto::MeCabNode)
+      }
+    end
+
+    subject { lyric.nauns }
+    it { is_expected.to include nauns }
+
+    describe '#[0]' do
+      describe '#feature' do
+        subject { lyric.nauns[0].feature }
+        it { is_expected.to match /\A名詞/ }
+      end
+    end
+  end
+end

--- a/spec/rhymer/parser_spec.rb
+++ b/spec/rhymer/parser_spec.rb
@@ -1,0 +1,61 @@
+describe Rhymer::Parser do
+  let(:text) { '今日はとても良い天気ですね。こんな日は自然に元気になります。' }
+  let(:parser) { described_class.new(text) }
+
+  describe '.new' do
+    context 'given text' do
+      subject { parser }
+      it { is_expected.to be_instance_of described_class }
+      it { is_expected.to respond_to(:lyric) }
+      it { is_expected.not_to respond_to(:lyric=) }
+      it { is_expected.to respond_to(:rhymes) }
+      it { is_expected.not_to respond_to(:rhymes=) }
+    end
+
+    context 'given nil text' do
+      let(:text) { nil }
+
+      subject { -> { parser } }
+      it { is_expected.to raise_error(NoMethodError, "undefined method `gsub' for nil:NilClass") }
+    end
+  end
+
+  describe '#lyric' do
+    subject { parser.lyric }
+    it { is_expected.to be_instance_of Rhymer::Lyric }
+  end
+
+  describe '#rhymes' do
+    subject { parser.rhymes }
+
+    context 'with default config' do
+      context 'given rhymed text' do
+        it { is_expected.to eq [['今日は良い天気', 'こんな日は自然に元気', 20]] }
+      end
+
+      context 'given no rhymed text' do
+        let(:text) { '今日はとても良い天気ですね。' }
+        it { is_expected.to eq [] }
+      end
+    end
+
+    context 'with custom config' do
+      let(:parser) { described_class.new(text, config) }
+
+      context 'given low config[:vibes_threshold]' do
+        let(:config) { { vibes_threshold: 19, prefix_length: 4 } }
+        it { is_expected.to eq [['今日は良い天気', 'こんな日は自然に元気', 20]] }
+      end
+
+      context 'given high config[:vibes_threshold]' do
+        let(:config) { { vibes_threshold: 20, prefix_length: 4 } }
+        it { is_expected.to eq [] }
+      end
+
+      context 'given config[:prefix_length]' do
+        let(:config) { { vibes_threshold: 4, prefix_length: 0 } }
+        it { is_expected.to eq [['良い天気', 'こんな日は自然に元気', 20]] }
+      end
+    end
+  end
+end

--- a/spec/rhymer_spec.rb
+++ b/spec/rhymer_spec.rb
@@ -1,11 +1,6 @@
-require 'spec_helper'
-
 describe Rhymer do
-  it 'has a version number' do
-    expect(Rhymer::VERSION).not_to be nil
-  end
-
-  it 'does something useful' do
-    expect(false).to eq(true)
+  describe 'VERSION' do
+    subject { described_class::VERSION }
+    it { is_expected.not_to be_nil }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'rhymer'
+require 'rhymer/cli'


### PR DESCRIPTION
Usage: `rake`

Results:
```
Rhymer::CLI
  #spit
    given short text
      should output "今日は良い天気 こんな日は自然に元気\n" to stdout
    given long text
      should output /25日大坂城に入城 将軍は大阪を発ち同月16日入京\n/ to stdout

Rhymer::Lyric
  .new
    given text
      should be an instance of Rhymer::Lyric
      should respond to #lyric
      should not respond to #lyric=
    given nil text
      should raise ArgumentError with "Text to parse cannot be nil"
  #lyric
    should include (an instance of Natto::MeCabNode)
  #mecab
    should be an instance of Natto::MeCab
  #nauns
    should include {0 => (an instance of Natto::MeCabNode), 4 => (an instance of Natto::MeCabNode)}
    #[0]
      #feature
        should match /\A名詞/

Rhymer::Parser
  .new
    given text
      should be an instance of Rhymer::Parser
      should respond to #lyric
      should not respond to #lyric=
      should respond to #rhymes
      should not respond to #rhymes=
    given nil text
      should raise NoMethodError with "undefined method `gsub' for nil:NilClass"
  #lyric
    should be an instance of Rhymer::Lyric
  #rhymes
    with default config
      given rhymed text
        should eq [["今日は良い天気", "こんな日は自然に元気", 20]]
      given no rhymed text
        should eq []
    with custom config
      given low config[:vibes_threshold]
        should eq [["今日は良い天気", "こんな日は自然に元気", 20]]
      given high config[:vibes_threshold]
        should eq []
      given config[:prefix_length]
        should eq [["良い天気", "こんな日は自然に元気", 20]]

Rhymer
  VERSION
    should not be nil

Finished in 1.61 seconds (files took 0.39487 seconds to load)
23 examples, 0 failures
```

I decided to use RSpec because spec/spec_helper.rb already exists.

現状（v0.0.4）の実装に合わせてテストコードを書いてみました。
既に spec/spec_helper.rb がありましたので、テスティングフレームワークには RSpec を使用しています。