### PR TITLE
Fix `No examples found.` on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
   - make
   - sudo make install
   - sudo ldconfig
+  - cd $base_dir
   - gem install bundler
 before_script:
   - bundle install


### PR DESCRIPTION
The examples seem not to have been executed.
https://travis-ci.org/suzuki86/rhymer/builds/142484467

`rspec` command should be executed in `$base_dir`.

RSpec でのテストが Travis CI 上で実行されていないようです。
`mecab-ipadic-2.7.0-20070801` ディレクトリで `rspec` を実行していることが原因ではないかと考え、`.travis.yml` を修正してみました。