### PR TITLE
Do not start CLI when executing `rspec`

### DIFF
--- a/exe/rhymer
+++ b/exe/rhymer
@@ -1,3 +1,5 @@
 #!/usr/bin/env ruby
 
 require "rhymer/cli"
+
+Rhymer::CLI.start

--- a/lib/rhymer/cli.rb
+++ b/lib/rhymer/cli.rb
@@ -20,6 +20,4 @@ module Rhymer
       puts "rhymer #{Rhymer::VERSION}"
     end
   end
-
-  CLI.start
 end


### PR DESCRIPTION
Avoid outputting following unnecessary log when executing `rspec`.
```
Commands:
  rspec -v, --version   # Print the version
  rspec help [COMMAND]  # Describe available commands or one specific command
  rspec spit TEXT       # Detect and print rhymes in the TEXT
```

`rspec` 実行時に上記の不要なログが出力されないよう、 `CLI.start` は `exe/rhymer` 実行時にのみ実行されるようにしました。